### PR TITLE
Wrap problematic JSON.parse() in try catch

### DIFF
--- a/client.js
+++ b/client.js
@@ -22,9 +22,13 @@ class Client extends EventEmitter {
 
     this.hangupsProc.stdout.on("data", (str) => {
       debugVerbose("got message from hangups before JSON.parse():", str.toString());
-      var data = JSON.parse(str);
-      debugVerbose("emitting message", data);
-      this.emit('message', data);
+      try {
+        var data = JSON.parse(str);
+        debugVerbose("emitting message", data);
+        this.emit('message', data);
+	  } catch {
+		debugVerbose("ERROR: incorrect JSON format: ", str.toStrin());
+	  }
     });
 
     console.log('started hangups child');

--- a/client.js
+++ b/client.js
@@ -26,9 +26,9 @@ class Client extends EventEmitter {
         var data = JSON.parse(str);
         debugVerbose("emitting message", data);
         this.emit('message', data);
-	  } catch {
-		debugVerbose("ERROR: incorrect JSON format: ", str.toStrin());
-	  }
+      } catch {
+        debugVerbose("ERROR: incorrect JSON format: ", str.toStrin());
+      }
     });
 
     console.log('started hangups child');


### PR DESCRIPTION
This is not a great solution, but it is a functional one.
I have been using this personally for a couple of weeks now, no major issues, this will loose messages if they are sent faster than the synapse ratelimit, but I am not sure if that is due to this 'fix' or a limitation in the puppet bridge lacking retry logic.

The root cause of this issue seems to be an insuffecient check inside of hangups that sends two message's JSON at the same time, thereby causing a parse error. But if that simply fails, the messages still come through for whatever reason?

Anyway I do not have enough time to go through and fix this properly from the hangups side for a protocol Google will likely kill in the near future.

feedback welcome

fixes #22 