### PR TITLE
Add debug environment variable to systemd service

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ Description=Hangouts Matrix Puppet
 
 [Service]
 Type=simple
+Environment=DEBUG=verbose:matrix-puppet:*
 User=my-user-who-is-running-puppet-here
 Group=my-group-who-is-running-puppet-here
 WorkingDirectory=/my/path/to/downloaded/puppet/here


### PR DESCRIPTION
It's useful to have logs with actual content in them. We should encourage people who are running this in a systemd service to set the correct environment variables to have proper debug logging.