### PR TITLE
Point matrix-puppet-bridge to c169af to fix broken config file reading

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "license": "ISC",
   "dependencies": {
     "bluebird": "^3.4.7",
-    "matrix-puppet-bridge": "matrix-hacks/matrix-puppet-bridge#8a8cea3"
+    "matrix-puppet-bridge": "matrix-hacks/matrix-puppet-bridge#c16ac9f"
   },
   "devDependencies": {
     "eslint": "^3.12.2"


### PR DESCRIPTION
As recently discovered by a new user, parsing the config.json file is broken, so setting up a new bridge fails. This was fixed by [this commit](https://github.com/matrix-hacks/matrix-puppet-bridge/commit/c16ac9faa2599880c93764a7fb7ce94cabfabb4d), but package.json still points to an older commit.