### PR TITLE
Fix room aliases, improve attachment handling for Slack -> Matrix

### DIFF
--- a/index.js
+++ b/index.js
@@ -62,7 +62,7 @@ class App extends MatrixPuppetBridgeBase {
               sendStatusMsg({}, "handleThirdPartyRoomMessage error", err);
             });
           }
-          // image message
+          // message with attachment
           return Promise.all(data.attachments.map((attachment)=> {
             const payload = {
               roomId: data.conversation_id,
@@ -72,7 +72,7 @@ class App extends MatrixPuppetBridgeBase {
               url: attachment,
               avatarUrl: data.photo_url,
             };
-            return this.handleThirdPartyRoomImageMessage(payload).catch(err => {
+            return this.handleThirdPartyRoomMessageWithAttachment(payload).catch(err => {
               console.log("handleThirdPartyRoomMessage error", err);
               sendStatusMsg({}, "handleThirdPartyRoomMessage error", err);
             });

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "license": "ISC",
   "dependencies": {
     "bluebird": "^3.4.7",
-    "matrix-puppet-bridge": "matrix-hacks/matrix-puppet-bridge#c16ac9f"
+    "matrix-puppet-bridge": "matrix-hacks/matrix-puppet-bridge#186331f"
   },
   "devDependencies": {
     "eslint": "^3.12.2"

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "license": "ISC",
   "dependencies": {
     "bluebird": "^3.4.7",
-    "matrix-puppet-bridge": "matrix-hacks/matrix-puppet-bridge#decce78"
+    "matrix-puppet-bridge": "michaelnew/matrix-puppet-bridge"
   },
   "devDependencies": {
     "eslint": "^3.12.2"


### PR DESCRIPTION
Two simple fixes:  
* point package.json to the latest matrix-puppet-bridge to include [this](https://github.com/matrix-hacks/matrix-puppet-bridge/pull/69) fix for room aliases
* Use `handleThirdPartyRoomMessageWithAttachment` rather than `handleThirdPartyRoomImageMessage` to better handle incoming message attachments (image, video, files, etc.)
